### PR TITLE
bump to 0.7

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: pytaku
-version: 0-6
+version: 0-7
 runtime: python27
 api_version: 1
 threadsafe: yes


### PR DESCRIPTION
A lot has changed; 0.7 will probably be the last version of this incarnation of Pytaku before The Big Rewrite.
